### PR TITLE
Add generic DebouncerExt trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ use doc_comment::doc_comment;
 /// To create an instance, use the appropriate `debounce_X` function (where `X`
 /// is the number of required consecutive logical-high states).
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct Debouncer<M>
 where
     M: RepeatN,
@@ -217,6 +218,7 @@ where
 /// (and vice versa).
 ///
 /// The memory cost for this is storing an extra enum value per debouncer.
+#[derive(Clone)]
 pub struct DebouncerStateful<M>
 where
     M: RepeatN,
@@ -239,9 +241,9 @@ mod seal {
 }
 
 /// A trait that represents all RepeatN structs
-pub trait RepeatN: seal::Sealed + Clone + Copy {
+pub trait RepeatN: seal::Sealed + Clone {
     /// The inner type wrapped by Debouncer
-    type Type;
+    type Type: Clone;
 }
 
 /// A trait to group all initializable Debouncer<M>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ mod seal {
 }
 
 /// A trait that represents all RepeatN structs
-pub trait RepeatN: seal::Sealed {
+pub trait RepeatN: seal::Sealed + Clone + Copy {
     /// The inner type wrapped by Debouncer
     type Type;
 }
@@ -273,6 +273,7 @@ macro_rules! impl_logic {
                 $count,
                 ".html).",
             ),
+            #[derive(Clone, Copy)]
             pub struct $M;
         }
 


### PR DESCRIPTION
This PR addresses the need for a generic `Debouncer<T, M>` implementation by introducing a trait around all `RepeatN` types. This trait encapsulates the correct associated type for each `RepeatN`.

For example, Repeat4, when passed to Debouncer<T, M>, now automatically provides T through its associated type.
As a result, Debouncer<u8, Repeat4> can now be simplified to Debouncer<Repeat4>.

```rust
impl RepeatN for Repeat4 {
    type Type = u8;
}
```

Additionally, a `DebouncerExt` trait has been implemented for all debouncers. This enables all the separate initializers, such as `debounce_n(bool)`, to be unified under `DebouncerExt::new(bool)`.
This change allows users to define a generic `Debouncer<M>` in functions and types via type parameters.

```rust
struct Button<T: DebouncerExt> {
    debouncer: T,
}

impl<T: DebouncerExt> Button<T> {
    pub fn new(initial_state: bool) -> Self {
        Self {
            debouncer: T::new(initial_state),
        }
    }

    pub fn update(&mut self, pressed: bool) -> Option<Edge> {
        self.debouncer.update(pressed)
    }
}
```

---

This is just a draft. I have only made minimal edits to the documentation to ensure the tests pass and to present this PR as a proposal.